### PR TITLE
support env vars for configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/envato/iodized2_ruby_client
-  revision: 9de005ce4403cb85b97dcc2e438338f16aa50395
+  revision: 540459f0bc0f3258536ebfc8ee19eafc4cf6a114
   branch: master
   specs:
     iodized2_ruby_client (0.1.0)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Hello Iodized
+
+Sample application that uses Iodized2 as a source of feature flags.
+
+## Usage
+
+Several environment variables are supported.
+They all have default values which make running this server in development easier.
+They will all need to be specified in a production environment.
+
+* IODIZED_URL
+  * the websocket URL
+  * defaults to `ws://localhost:4000/features_socket/websocket`
+* IODIZED_KEY
+  * the key registered in Iodized
+  * defaults to `key`
+* IODIZED_SECRET
+  * the secret associated with the key
+  * defaults to `secret`
+
+```bash
+# optionally, set up ENV vars:
+> IODIZED_URL=<websocket URL>
+> IODIZED_KEY=<client key>
+> IODIZED_SECRET=<client secret>
+# run the server:
+> bundle exec rackup
+```

--- a/hello.rb
+++ b/hello.rb
@@ -1,7 +1,10 @@
 require "sinatra"
 require "iodized2_ruby_client"
 
-iodized = Iodized2RubyClient.new("ws://localhost:4000/features_socket/websocket", "key", "secret")
+iodized_url = ENV.fetch("IODIZED_URL", "ws://localhost:4000/features_socket/websocket")
+iodized_key = ENV.fetch("IODIZED_KEY", "key")
+iodized_secret = ENV.fetch("IODIZED_SECRET", "secret")
+iodized = Iodized2RubyClient.new(iodized_url, iodized_key, iodized_secret)
 
 get "/" do
   erb :hello, locals: {awesome_feature: iodized.enabled?('awesome_feature') }


### PR DESCRIPTION
Prior to this we were hard-coded to talk only to the local development server.

This change allows env var to configure where the iodized server is (needed for heroku deployment I think).,
